### PR TITLE
Bump immer naar 8.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -238,7 +238,7 @@
         "@types/urijs": "^1.19.9",
         "dependency-graph": "~0.8.0",
         "fast-memoize": "^2.5.1",
-        "immer": "^5.3.2",
+        "immer": "^8.0.1",
         "lodash": "^4.17.15",
         "tslib": "^1.13.0",
         "urijs": "^1.19.2"
@@ -1574,10 +1574,9 @@
       }
     },
     "immer": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-5.3.6.tgz",
-      "integrity": "sha512-pqWQ6ozVfNOUDjrLfm4Pt7q4Q12cGw2HUZgry4Q5+Myxu9nmHRkWBpI0J4+MK0AxbdFtdMTwEGVl7Vd+vEiK+A==",
-      "dev": true
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
     },
     "import-fresh": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "hooks": {
       "pre-commit": "npm run oas:lint && npm run oas:resolve && npm run oas:lint-genereervariant"
     }
+  },
+  "dependencies": {
+    "immer": "^8.0.1"
   }
 }


### PR DESCRIPTION
Vanwege dependabot melding.
Lokaal gecheckt, heeft geen impact op het genereren van de geresolved versie van openapi.yaml.