### PR TITLE
fix: variabelen conform Java Cucumber implementatie, en volgorde JSON

### DIFF
--- a/features/belanghebbende_naam.feature
+++ b/features/belanghebbende_naam.feature
@@ -9,7 +9,7 @@ Functionaliteit: Als gebruiker wil ik de naam zien van de geleverde belanghebben
     En deze persoon heeft als voorletters "A.B.C."
     En deze persoon heeft als voorvoegsel geslachtsnaam "in het"
     En deze persoon heeft als geslachtsnaam "Veld"
-    Als het WOZ object wordt opgevraagd met /wozobjecten/002500003118
+    Als het WOZ object wordt opgevraagd met "/wozobjecten/002500003118"
     Dan bevat het antwoord:
     """
     "belanghebbendeEigenaar": {
@@ -24,7 +24,7 @@ Functionaliteit: Als gebruiker wil ik de naam zien van de geleverde belanghebben
     En deze persoon heeft als voorletters "D."
     En deze persoon heeft geen waarde voor voorvoegsel geslachtsnaam
     En deze persoon heeft als geslachtsnaam "Groenen"
-    Als het WOZ object wordt opgevraagd met /wozobjecten/082600014669
+    Als het WOZ object wordt opgevraagd met "/wozobjecten/082600014669"
     Dan bevat het antwoord:
     """
     "belanghebbendeEigenaar": {
@@ -37,13 +37,14 @@ Functionaliteit: Als gebruiker wil ik de naam zien van de geleverde belanghebben
   Scenario: de naam van een niet-natuurlijk persoon is de statutaire naam
     Gegeven de belanghebbendeEigenaar van het WOZ object met identificatie "050300024029" is de niet-natuurlijk persoon met rsin "858311537"
     En deze niet-natuurlijk persoon heeft als statutaire naam "Test Stichting Bolderbast"
-    Als het WOZ object wordt opgevraagd met /wozobjecten/050300024029
+    En deze niet-natuurlijk persoon heeft als KvKNummer "69599068"
+    Als het WOZ object wordt opgevraagd met "/wozobjecten/050300024029"
     Dan bevat het antwoord:
     """
     "belanghebbendeEigenaar": {
-         "rsin": "858311537",
          "kvkNummer": "69599068",
          "naam": "Test Stichting Bolderbast",
+         "rsin": "858311537",
          "type": "niet_natuurlijk_persoon"
     }
     """
@@ -51,13 +52,14 @@ Functionaliteit: Als gebruiker wil ik de naam zien van de geleverde belanghebben
   Scenario: de naam van een vestiging is de handelsnaam
     Gegeven de belanghebbendeEigenaar van het WOZ object met identificatie "051800823525" is de vestiging met vestigingsnummer "000037143557"
     En deze vestiging heeft als handelsnaam "Test NV Katrien"
-    Als het WOZ object wordt opgevraagd met /wozobjecten/050300024029
+    En deze vestiging heeft als KvKNummer "68727720"
+    Als het WOZ object wordt opgevraagd met "/wozobjecten/050300024029"
     Dan bevat het antwoord:
     """
     "belanghebbendeEigenaar": {
-         "vestigingsnummer": "000037143557",
          "kvkNummer": "68727720",
          "naam": "Test NV Katrien",
          "type": "vestiging"
+         "vestigingsnummer": "000037143557",
     }
     """


### PR DESCRIPTION
Bij het draaien van de belanghebbende naam feature kwam ik een paar dingen tegen.
- De Java implementatie van Cucumber verwacht standaard string variabelen als "een string".
- De velden van het JSON Object voor BelanghebbendeEigenaar is alfabetisch gesorteerd.