### PR TITLE
Correctie op links en teksten

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 API voor het zoeken en raadplegen van WOZ objecten en WOZ waardes.
 
-## Direct uitproberen?
+## Direct aan de slag?
 * Lees de [Getting started](https://vng-realisatie.github.io/Haal-Centraal-WOZ-bevragen/getting-started)
 * Bekijk de specificaties met [Swagger UI](https://vng-realisatie.github.io/Haal-Centraal-WOZ-bevragen/swagger-ui) en in [Redoc](https://vng-realisatie.github.io/Haal-Centraal-WOZ-bevragen/redoc)
 * Download de [Technische specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-WOZ-bevragen/tree/master/specificatie/genereervariant/openapi.yaml)

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ API voor het zoeken en raadplegen van WOZ objecten en WOZ waardes.
 * Lees de [Getting started](https://vng-realisatie.github.io/Haal-Centraal-WOZ-bevragen/getting-started)
 * Bekijk de specificaties met [Swagger UI](https://vng-realisatie.github.io/Haal-Centraal-WOZ-bevragen/swagger-ui) en in [Redoc](https://vng-realisatie.github.io/Haal-Centraal-WOZ-bevragen/redoc)
 * Download de [Technische specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-WOZ-bevragen/tree/master/specificatie/genereervariant/openapi.yaml)
+<!-- * [Vraag een API-key aan](https://formulieren.kadaster.nl/aanmelden_brk_bevragen) voor toegang tot de testomgeving.-->
 
 ## Bronnen
 
-* [Productvisie Haal Centraal](https://vng-realisatie.github.io/Haal-Centraal)
 * [API Design Visie](https://github.com/Geonovum/KP-APIs/blob/master/overleggen/Werkgroep%20API%20design%20visie/API%20Design%20Visie.md)
 * [REST API Design Rules](https://docs.geostandaarden.nl/api/API-Designrules/)
 * [Landelijke API strategie voor de overheid](https://geonovum.github.io/KP-APIs/)
-* [Stelselcatalogus](https://www.stelselcatalogus.nl/registraties/WOZ/)
+* [Stelselcatalogus](https://www.stelselcatalogus.nl/registraties/registratie?id=http://opendata.stelselcatalogus.nl/id/registratie/WOZ)
 
 ## Contact
 
@@ -27,9 +27,11 @@ API voor het zoeken en raadplegen van WOZ objecten en WOZ waardes.
 * Community: Wil je geïnformeerd blijven over productwijzigingen of meepraten over de API meld je dan aan bij de community.<br/><a href="https://haalcentraal.pleio.nl/groups/view/6dc1ac46-ec6e-47cc-bcab-ce586d8962b0/community-woz-api">Ga naar de community>></a>
 
 
-* Regiseur API's: Arjen Brienen, [arjen.brienen@VNG.NL](mailto:arjen.brienen@VNG.NL)
-* Designer: Johan Boer, [johan.boer@vng.nl](mailto:johan.boer@vng.nl)
-* Designer: Robert Melskens, [robert.melskens@vng.nl](mailto:robert.melskens@vng.nl)
+* Regiseur API's: Arjen Brienen
+* Designer: Johan Boer
+* Designer: Robert Melskens
+
+U kunt hen bereiken via [standaarden.ondersteuning@vng.nl](mailto:standaarden.ondersteuning@vng.nl)
 
 ## Licentie
 Copyright &copy; VNG Realisatie 2020

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: page-with-side-nav
 title: Haal Centraal WOZ bevragen
 ---
 
-# Haal Centraal WOZ bevragen v1.0 is live!
+# Haal Centraal WOZ bevragen
 
 ![lint oas](https://github.com/VNG-Realisatie/Haal-Centraal-WOZ-bevragen/workflows/lint-oas/badge.svg)
 ![generate postman collection](https://github.com/VNG-Realisatie/Haal-Centraal-WOZ-bevragen/workflows/generate-postman-collection/badge.svg)


### PR DESCRIPTION
O.a.:

* Check op links en teksten
  - In README.md
    - Geen individuele e-Mailadressen meer in de 'Contacten' paragraaf;
    - Inhoud gelijk gemaakt aan 'index.md' (main pagina van GitHub Pages);
  - index.md (main pagina van GitHub Pages)
    - De link 'Stelselcatalogus' werkte niet meer. Deze verwees naar:<br/><br/>*https://www.stelselcatalogus.nl/registraties/WOZ/*<br/><br/>maar moet waarschijnlijk verwijzen naar:<br/><br/>*https://www.stelselcatalogus.nl/registraties/registratie?id=http://opendata.stelselcatalogus.nl/id/registratie/WOZ*<br/><br/>Dit heb ik in deze PR aangepast maar graag even aangeven of dit klopt.